### PR TITLE
Invoked expressions to be able to combine complex expressions

### DIFF
--- a/src/Logic/Movies/Specification.cs
+++ b/src/Logic/Movies/Specification.cs
@@ -6,12 +6,11 @@ namespace Logic.Movies
 {
     internal sealed class IdentitySpecification<T> : Specification<T>
     {
-        public override Expression<Func<T, bool>> ToExpression() 
+        public override Expression<Func<T, bool>> ToExpression()
         {
             return x => true;
         }
     }
-
 
     public abstract class Specification<T>
     {
@@ -25,7 +24,7 @@ namespace Logic.Movies
 
         public abstract Expression<Func<T, bool>> ToExpression();
 
-        public Specification<T> And(Specification<T> specification) 
+        public Specification<T> And(Specification<T> specification)
         {
             if (this == All)
                 return specification;
@@ -35,7 +34,7 @@ namespace Logic.Movies
             return new AndSpecification<T>(this, specification);
         }
 
-        public Specification<T> Or(Specification<T> specification) 
+        public Specification<T> Or(Specification<T> specification)
         {
             if (this == All || specification == All)
                 return All;
@@ -48,7 +47,6 @@ namespace Logic.Movies
             return new NotSpecification<T>(this);
         }
     }
-
 
     internal sealed class AndSpecification<T> : Specification<T>
     {
@@ -72,7 +70,6 @@ namespace Logic.Movies
         }
     }
 
-
     internal sealed class OrSpecification<T> : Specification<T>
     {
         private readonly Specification<T> _left;
@@ -84,7 +81,7 @@ namespace Logic.Movies
             _left = left;
         }
 
-        public override Expression<Func<T, bool>> ToExpression() 
+        public override Expression<Func<T, bool>> ToExpression()
         {
             Expression<Func<T, bool>> leftExpression = _left.ToExpression();
             Expression<Func<T, bool>> rightExpression = _right.ToExpression();
@@ -94,7 +91,6 @@ namespace Logic.Movies
             return (Expression<Func<T, Boolean>>)Expression.Lambda(Expression.OrElse(leftExpression.Body, invokedExpression), leftExpression.Parameters);
         }
     }
-
 
     internal sealed class NotSpecification<T> : Specification<T>
     {
@@ -114,7 +110,6 @@ namespace Logic.Movies
         }
     }
 
-
     public sealed class MovieForKidsSpecification : Specification<Movie>
     {
         public override Expression<Func<Movie, bool>> ToExpression()
@@ -122,7 +117,6 @@ namespace Logic.Movies
             return movie => movie.MpaaRating <= MpaaRating.PG;
         }
     }
-
 
     public sealed class AvailableOnCDSpecification : Specification<Movie>
     {
@@ -133,7 +127,6 @@ namespace Logic.Movies
             return movie => movie.ReleaseDate <= DateTime.Now.AddMonths(-MonthsBeforeDVDIsOut);
         }
     }
-
 
     public sealed class MovieDirectedBySpecification : Specification<Movie>
     {

--- a/src/Logic/Movies/Specification.cs
+++ b/src/Logic/Movies/Specification.cs
@@ -6,7 +6,7 @@ namespace Logic.Movies
 {
     internal sealed class IdentitySpecification<T> : Specification<T>
     {
-        public override Expression<Func<T, bool>> ToExpression()
+        public override Expression<Func<T, bool>> ToExpression() 
         {
             return x => true;
         }
@@ -17,7 +17,7 @@ namespace Logic.Movies
     {
         public static readonly Specification<T> All = new IdentitySpecification<T>();
 
-        public bool IsSatisfiedBy(T entity)
+        public bool IsSatisfiedBy(T entity) 
         {
             Func<T, bool> predicate = ToExpression().Compile();
             return predicate(entity);
@@ -25,7 +25,7 @@ namespace Logic.Movies
 
         public abstract Expression<Func<T, bool>> ToExpression();
 
-        public Specification<T> And(Specification<T> specification)
+        public Specification<T> And(Specification<T> specification) 
         {
             if (this == All)
                 return specification;
@@ -35,7 +35,7 @@ namespace Logic.Movies
             return new AndSpecification<T>(this, specification);
         }
 
-        public Specification<T> Or(Specification<T> specification)
+        public Specification<T> Or(Specification<T> specification) 
         {
             if (this == All || specification == All)
                 return All;
@@ -43,7 +43,7 @@ namespace Logic.Movies
             return new OrSpecification<T>(this, specification);
         }
 
-        public Specification<T> Not()
+        public Specification<T> Not() 
         {
             return new NotSpecification<T>(this);
         }
@@ -66,9 +66,9 @@ namespace Logic.Movies
             Expression<Func<T, bool>> leftExpression = _left.ToExpression();
             Expression<Func<T, bool>> rightExpression = _right.ToExpression();
 
-            BinaryExpression andExpression = Expression.AndAlso(leftExpression.Body, rightExpression.Body);
+            var invokedExpression = Expression.Invoke(rightExpression, leftExpression.Parameters);
 
-            return Expression.Lambda<Func<T, bool>>(andExpression, leftExpression.Parameters.Single());
+            return (Expression<Func<T, Boolean>>)Expression.Lambda(Expression.AndAlso(leftExpression.Body, invokedExpression), leftExpression.Parameters);
         }
     }
 
@@ -84,14 +84,14 @@ namespace Logic.Movies
             _left = left;
         }
 
-        public override Expression<Func<T, bool>> ToExpression()
+        public override Expression<Func<T, bool>> ToExpression() 
         {
             Expression<Func<T, bool>> leftExpression = _left.ToExpression();
             Expression<Func<T, bool>> rightExpression = _right.ToExpression();
 
-            BinaryExpression orExpression = Expression.OrElse(leftExpression.Body, rightExpression.Body);
+            var invokedExpression = Expression.Invoke(rightExpression, leftExpression.Parameters);
 
-            return Expression.Lambda<Func<T, bool>>(orExpression, leftExpression.Parameters.Single());
+            return (Expression<Func<T, Boolean>>)Expression.Lambda(Expression.OrElse(leftExpression.Body, invokedExpression), leftExpression.Parameters);
         }
     }
 

--- a/src/Logic/Movies/Specification.cs
+++ b/src/Logic/Movies/Specification.cs
@@ -16,7 +16,7 @@ namespace Logic.Movies
     {
         public static readonly Specification<T> All = new IdentitySpecification<T>();
 
-        public bool IsSatisfiedBy(T entity) 
+        public bool IsSatisfiedBy(T entity)
         {
             Func<T, bool> predicate = ToExpression().Compile();
             return predicate(entity);
@@ -42,7 +42,7 @@ namespace Logic.Movies
             return new OrSpecification<T>(this, specification);
         }
 
-        public Specification<T> Not() 
+        public Specification<T> Not()
         {
             return new NotSpecification<T>(this);
         }


### PR DESCRIPTION
I invoked expressions before `AndAlso` and `OrElse` methods to be able to combine complex expressions. I can not combine following specifications without invoking.

```
public class PackageIdSpecification : Specification<Package>
{
    private readonly long packageId;

    public PackageIdSpecification(long packageId) {
        this.packageId = packageId;
    }

    public override Expression<Func<Package, bool>> ToExpression() {
        return p => p.Id == packageId;
    }
}
```
```
public class ChangesetNumberSpecification : Specification<Package>
{
    private readonly int changeset;

    public ChangesetNumberSpecification(int changeset) {
        this.changeset = changeset;
    }

    public override Expression<Func<Package, bool>> ToExpression() {
        return p => p.PackageDetails.Any(pd => pd.Changesets.Any(c => c.ChangesetNumber == changeset));
    }
}
```